### PR TITLE
Add response body auto-formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,32 @@ redirects. It's turned off by default. To enable
 
     let g:vrc_follow_redirects = 1
 
+#### `vrc_auto_format_response_enabled`
+
+This option enables the automatic formatting of the response. It's enabled by
+default. To disable:
+
+    let g:vrc_auto_format_response_enabled = 0
+
+#### `vrc_auto_format_response_patterns`
+
+This option defines which external tools to use to auto-format the response
+body according to the Content-Type.
+
+The defaults are:
+
+    let s:vrc_auto_format_response_patterns = {
+    \    'json': 'python -m json.tool',
+    \    'xml': 'xmllint --format -',
+    \ }
+
+Adjust the list by defining the global or buffer variable, like so:
+
+    let g:vrc_auto_format_response_patterns = {
+    \   'json': ''
+    \   'xml': 'tidy -xml -i -'
+    \ }
+
 #### `vrc_debug`
 
 This option enables the debug mode by adding the `-v` option to the *curl*

--- a/doc/vim-rest-console.txt
+++ b/doc/vim-rest-console.txt
@@ -27,6 +27,8 @@ CONTENTS                                                         *VrcContents*
       vrc_set_default_mapping..................... |vrc_set_default_mapping|
       vrc_nl_sep_post_data_patterns......... |vrc_nl_sep_post_data_patterns|
       vrc_follow_redirects........................... |vrc_follow_redirects|
+      vrc_auto_format_response_enabled... |vrc_auto_format_response_enabled|
+      vrc_auto_format_response_patterns..|vrc_auto_format_response_patterns|
       vrc_debug................................................. |vrc_debug|
   7. TODOs....................................................... |VrcTodos|
   8. Contributors......................................... |VrcContributors|
@@ -315,6 +317,35 @@ This option enables the cURL -L/--location option that makes it follow
 redirects. It's turned off by default. To enable
 >
     let g:vrc_follow_redirects = 1
+<
+------------------------------------------------------------------------------
+*vrc_auto_format_response_enabled*
+
+This option enables the automatic formatting of the response. It's enabled by
+default. To disable:
+>
+    let g:vrc_auto_format_response_enabled = 0
+<
+------------------------------------------------------------------------------
+*vrc_auto_format_response_patterns*
+
+This option defines which external tools to use to auto-format the response
+body according to the Content-Type.
+
+The defaults are:
+>
+    let s:vrc_auto_format_response_patterns = {
+    \    'json': 'python -m json.tool',
+    \    'xml': 'xmllint --format -',
+    \ }
+>
+
+Adjust the list by defining the global or buffer variable, like so:
+>
+    let g:vrc_auto_format_response_patterns = {
+    \   'json': ''
+    \   'xml': 'tidy -xml -i -'
+    \ }
 <
 ------------------------------------------------------------------------------
 *vrc_debug*

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -1,3 +1,8 @@
+let s:vrc_auto_format_response_patterns = {
+      \ 'json': 'python -m json.tool',
+      \ 'xml': 'xmllint --format -',
+      \ }
+
 function! s:StrStrip(txt)
     return substitute(a:txt, '\v^\s*(.*)\s*$', '\1', 'g')
 endfunction
@@ -9,6 +14,16 @@ function! s:GetOptValue(opt, defVal)
     if exists('g:' . a:opt)
         return eval('g:' . a:opt)
     endif
+    return a:defVal
+endfunction
+
+function! s:GetDictValue(dictName, key, defVal)
+    for prefix in ['b', 'g', 's']
+      let varName = prefix . ':' . a:dictName
+      if exists(varName) && has_key(eval(varName), a:key)
+        return get(eval(varName), a:key)
+      endif
+    endfor
     return a:defVal
 endfunction
 
@@ -173,6 +188,36 @@ function! s:DisplayOutput(tmpBufName, output)
     setlocal modifiable
     silent! normal! ggdG
     call setline('.', split(substitute(a:output, '[[:return:]]', '', 'g'), '\v\n'))
+
+    if s:GetOptValue('vrc_auto_format_response_enabled', 1)
+
+      call cursor(1, 0)
+      let emptyLineNum = search('\v^\s*$', 'n')
+      let contentTypeLineNum = search('\v^Content-Type:', 'n', emptyLineNum)
+
+      if contentTypeLineNum > 0
+        let contentType = substitute(getline(contentTypeLineNum), '\v^Content-Type:\s*([^;[:blank:]]*).*$', '\1', 'g')
+        let fileType = substitute(contentType, '\v^.*/(.*\+)?(.*)$', '\2', 'g')
+        let formatCmd = s:GetDictValue('vrc_auto_format_response_patterns', fileType, '')
+
+        if !empty(formatCmd)
+          """ Auto-format response body
+          let formattedBody = system(formatCmd, join(getline(emptyLineNum + 0, '$'), "\n"))
+
+          if v:shell_error == 0
+            execute (emptyLineNum + 1) . ',$delete _'
+            call append('$', split(formattedBody, '\v\n'))
+          elseif s:GetOptValue('vrc_debug', 0)
+            echom "VRC: aut-format error: " . v:shell_error
+            echom formattedBody
+          endif
+
+        endif
+
+      endif
+
+    endif
+
     setlocal nomodifiable
     execute origWin . 'wincmd w'
 endfunction
@@ -227,3 +272,4 @@ endfunction
 if s:GetOptValue('vrc_set_default_mapping', 1)
     call VrcMap()
 endif
+


### PR DESCRIPTION
Response body of APIs are usually packed into one line, which makes it had to view.

This pull request will automatically format the body based on the returned Content-Type.

By default json will be formatted by 'python -m json.tool' and xml will be formatted by 'xmllint --format'.

Users are able to customize (and disable) formatters using the the `vrc_auto_format_response` variable.

Let me know your thoughts on including this. =)