### PR TITLE
Add global option to enable/disable response header inclusion

### DIFF
--- a/doc/vim-rest-console.txt
+++ b/doc/vim-rest-console.txt
@@ -28,6 +28,7 @@ CONTENTS                                                         *VrcContents*
       vrc_nl_sep_post_data_patterns......... |vrc_nl_sep_post_data_patterns|
       vrc_follow_redirects........................... |vrc_follow_redirects|
       vrc_debug................................................. |vrc_debug|
+      vrc_include_response_header............. |vrc_include_response_header|
   7. TODOs....................................................... |VrcTodos|
   8. Contributors......................................... |VrcContributors|
   9. License................................................... |VrcLicense|
@@ -322,6 +323,15 @@ redirects. It's turned off by default. To enable
 This option enables the debug mode by adding the '-v' option to the 'curl'
 command and also `echom` the command to the Vim console. It's turned off by
 default.
+
+------------------------------------------------------------------------------
+*vrc_include_response_header*
+
+This option enables the inclusion of the response header information mode by
+adding the '-i' option to the 'curl' command. It's turned on by default.
+To disable
+
+    let g:vrc_include_response_header = 0
 
 ==============================================================================
                                                                     *VrcTodos*

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -88,7 +88,11 @@ endfunction
 
 function! s:CallCurl(request)
     """ Construct CURL args.
-    let curlArgs = ['-isS']
+    let curlArgs = ['-sS']
+    let vrcIncludeHeader = s:GetOptValue('vrc_include_response_header', 1)
+    if vrcIncludeHeader
+        call add(curlArgs, '-i')
+    endif
     let vrcDebug = s:GetOptValue('vrc_debug', 0)
     if vrcDebug
         call add(curlArgs, '-v')


### PR DESCRIPTION
After working with VRC for a week I have found it nice to be able to display the results of the response without the response header information.  This lets me set my filetype to JSON and have a better experience within the buffer.