### PR TITLE
Allow the definition of global host and headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ For more examples, check out
 
 https://raw.githubusercontent.com/diepm/vim-rest-console/master/sample.rest
 
+there is also an alternative version using global settings:
+
+https://raw.githubusercontent.com/diepm/vim-rest-console/master/sample_global.rest
+
 The following examples assume that an ElasticSearch service is running at
 localhost. The pipe (`|`) indicates the current position of the cursor.
 
@@ -172,6 +176,28 @@ By default, the display/output buffer is named `__REST_response__`. If there
 are multiple VRC buffers, they all share the same display buffer. To have a
 separate output display for each VRC buffer, `b:vrc_output_buffer_name` can be
 set in the buffer scope.
+
+#### 5.1 Global Definitions
+
+A recent addition to VRC are global definitions. The global part is separated
+from the rest with three dashes `---`. Each query block has to start with three
+dashes as well. Essentially, the three dashes in the query block are replaced
+with the global definitions (so they should only contain host and header
+parts).
+
+    // global definitions
+    https://domain[:port]/...
+    Accept: application/json
+    ---
+
+    # Some documentation
+    ---
+    GET /some/query
+
+    # More documentation
+    ---
+    POST /form
+    var1=value
 
 ### 6. Configuration
 

--- a/sample_global.rest
+++ b/sample_global.rest
@@ -1,0 +1,94 @@
+// Global definitions of the queries
+http://localhost:9200
+Accept: application/json
+---
+
+#
+# View nodes status
+#
+---
+GET /_cat/nodes?v
+
+#
+# Add a new doc to the new 'testindex' and 'testtype'
+#
+---
+
+POST /testindex/testtype
+{
+    "name": "some name",
+    "value": "some value",
+    "date": "2015-01-01"
+}
+
+#
+# Search 'testindex'
+#
+---
+GET /testindex/_search?pretty
+
+#
+# View mapping.
+#
+---
+GET /testindex/testtype/_mapping?pretty
+
+#
+# Bulk-add new docs to 'testindex'
+#
+---
+
+POST /testindex/_bulk?pretty
+{ "create": { "_type": "testtype" }}
+{ "name": "FOO", "value": "think about BAR", "date": "2015-01-05" }
+{ "create": { "_type": "testtype" }}
+{ "name": "FOO", "value": "some value of FOO", "date": "2015-01-06" }
+{ "create": { "_type": "testtype" }}
+{ "name": "BAR", "value": "some value of BAR", "date": "2015-01-07" }
+{ "create": { "_type": "testtype" }}
+{ "name": "BAR", "value": "think about FOO", "date": "2015-01-08" }
+
+#
+# Lite search
+#
+---
+GET /testindex/testtype/_search?pretty q=+name:FOO +value:(FOO BAR)
+
+#
+# Full-body search
+#
+---
+
+POST /testindex/_search?pretty
+{
+    "query": {
+        "filtered": {
+            "filter": {
+                "range": {
+                    "date": {
+                        "gte": "2015-01-06",
+                        "lte": "2015-01-08"
+                    }
+                }
+            },
+            "query": {
+                "match": {
+                    "value": "FOO"
+                }
+            }
+        }
+    }
+}
+
+#
+# Delete 'testindex'
+#
+---
+DELETE /testindex?pretty
+
+#
+# Check for 'testindex' existence
+#
+---
+HEAD /testindex
+


### PR DESCRIPTION
This PR fixes #15 and defines a new (optional) global section in the rest file.

Like so:

```
http://localhost:9200
Accept: application/json
---

# Get all ES indices
---
GET /_cat/indices?v
```

Please note that this is my very first try with VimScript, so check whether there are newbie mistakes. Especially the jumging around in the rest buffer seems strange to me.

Shouldn't all variables within the functions be `local` scoped? The default seems to be `global`?