### PR TITLE
Improve support for multiple GET params

### DIFF
--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -271,7 +271,7 @@ function! s:GetCurlCommand(request)
     if !empty(dataBody)
         call add(
         \   curlArgs,
-        \   s:GetCurlDataOpt(httpVerb, dataBody) . ' ' . shellescape(dataBody)
+        \   s:GetCurlDataArgs(httpVerb, dataBody)
         \)
     endif
     return 'curl ' . join(curlArgs) . ' ' . shellescape(a:request.host . a:request.requestPath)
@@ -296,7 +296,7 @@ endfunction
 """
 " Get the cUrl option to include data body (--data, --data-urlencode...)
 "
-function! s:GetCurlDataOpt(httpVerb, dataBody)
+function! s:GetCurlDataArgs(httpVerb, dataBody)
     """ These verbs should have request body passed as POST params.
     if a:httpVerb ==? 'POST'
     \  || a:httpVerb ==? 'PUT'
@@ -305,14 +305,14 @@ function! s:GetCurlDataOpt(httpVerb, dataBody)
         """ Should load from a file?
         if stridx(a:dataBody, '@') == 0
             """ Load from a file.
-            return '--data-binary'
+            return '--data-binary ' . shellescape(a:dataBody)
         else
-            return '--data'
+            return '--data ' . shellescape(a:dataBody)
         endif
     endif
 
     """ For other cases, request body is passed as GET params.
-    return '--data-urlencode'
+    return '--data-urlencode ' . shellescape(a:dataBody)
 endfunction
 
 function! s:DisplayOutput(tmpBufName, output)

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -214,7 +214,7 @@ function! s:ParseRequest(start, end, globSection)
     \   'headers': headers,
     \   'httpVerb': httpVerb,
     \   'requestPath': join(queryPath, ''),
-    \   'dataBody': join(dataBody, '')
+    \   'dataBody': substitute(join(dataBody, "\n"), '\v\n$', '', '')
     \}
 endfunction
 
@@ -312,7 +312,11 @@ function! s:GetCurlDataArgs(httpVerb, dataBody)
     endif
 
     """ For other cases, request body is passed as GET params.
-    return '--data-urlencode ' . shellescape(a:dataBody)
+    let result = ""
+    for line in split(a:dataBody, '\v\n')
+      let result .= ' --data-urlencode ' . shellescape(line)
+    endfor
+    return result
 endfunction
 
 function! s:DisplayOutput(tmpBufName, output)


### PR DESCRIPTION
Example usage:

```
http://httpbin.org/
GET /get
key1=value1
key2=value2
key3=value3
```

Response without multi GET param support:

```json
{
    "args": {
        "key1": "value1key2=value2key3=value3"
    },
    "headers": {
        "Accept": "application/json",
        "Content-Type": "application/json",
        "Host": "httpbin.org",
        "User-Agent": "curl/7.43.0"
    },
    "origin": "150.101.176.147",
    "url": "http://httpbin.org/get?key1=value1key2%3Dvalue2key3%3Dvalue3"
}
```

Response with multi GET param support:

```json
{
    "args": {
        "key1": "value1",
        "key2": "value2",
        "key3": "value3"
    },
    "headers": {
        "Accept": "application/json",
        "Content-Type": "application/json",
        "Host": "httpbin.org",
        "User-Agent": "curl/7.43.0"
    },
    "origin": "150.101.176.147",
    "url": "http://httpbin.org/get?key1=value1&key2=value2&key3=value3"
}
```

Please note, with my use-case, I have a very long and complicated query string. Therefore I'd rather not have everything on the `GET` line, e.g. `GET /get?key1=value1&key2=value2&key3=value3`