### PR TITLE
Set commentstring for VRC buffers

### DIFF
--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -1,3 +1,5 @@
+setlocal commentstring=#%s
+
 let s:vrc_auto_format_response_patterns = {
 \   'json': 'python -m json.tool',
 \   'xml': 'xmllint --format -',


### PR DESCRIPTION
Allows for plugins such as tcomment to properly comment lines