### PR TITLE
properly set content-type to json when the user doesn't set any header

### DIFF
--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -114,7 +114,8 @@ endfunction
 " @return dict
 "
 function! s:ParseHeaders(start, end)
-    let headers = {}
+    let contentTypeOpt = s:GetOptValue('vrc_header_content_type', 'application/json')
+    let headers = {'Content-Type': contentTypeOpt}
     if (a:end < a:start)
         return headers
     endif
@@ -129,16 +130,9 @@ function! s:ParseHeaders(start, end)
         let sepIdx = stridx(line, ':')
         if sepIdx > -1
             let key = s:StrTrim(line[0:sepIdx - 1])
-            if key ==? 'Content-Type'
-                let hasContentType = 1
-            endif
             let headers[key] = s:StrTrim(line[sepIdx + 1:])
         endif
     endfor
-    if !hasContentType
-      let headers['Content-Type'] =
-      \   s:GetOptValue('vrc_header_content_type', 'application/json')
-    endif
     return headers
 endfunction
 


### PR DESCRIPTION
Hi,

According to the documentation, the default content-type should be application/json. However, if the user doesn't add any headers by hand, then the content-type is not set at all. This should fix that.