### PR TITLE
Support bulk requests

### DIFF
--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -204,7 +204,6 @@ endfunction
 " @return dict
 "
 function! s:ParseRequest(start, resumeFrom, end, globSection)
-    echom "start: " . a:start . " resumeFrom: " . a:resumeFrom . " end: " . a:end
     """ Parse host.
     let [lineNumHost, host] = s:ParseHost(a:start, a:end)
     if !lineNumHost

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -475,7 +475,7 @@ function! s:RunQuery(start, end)
         endif
 
         let curlCmd = s:GetCurlCommand(request)
-        if s:GetOptValue('vrc_debug', 1)
+        if s:GetOptValue('vrc_debug', 0)
             echom curlCmd
         endif
         silent !clear


### PR DESCRIPTION
This PR enables users to automatically run multiple requests and have their output concatenated in the destination buffer.

For example, if your scratch file looked like the following, only the first request (ie. `GET /posts/1`) would have been fired:
```
https://jsonplaceholder.typicode.com
GET /posts/1
GET /posts/2
GET /posts/3
GET /posts/4
```
This patch instead changes the plugin behavior so that all the 4 GET requests will be fired, one after the other.

It works with global settings too:

```
https://jsonplaceholder.typicode.com
--

--
GET /posts/1
--
GET /posts/2
GET /posts/3
GET /posts/4
```