### PR TITLE
Add vrc_resolve_to_ipv4 option option

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,13 @@ its own output display. For this, the option can be set in the buffer scope as
 
     let b:vrc_output_buffer_name = '__REST_1_OUTPUT__'
 
+#### `vrc_resolve_to_ipv4`
+
+This option forces names to be resolved to IPV4 addresses only by adding the
+'--ipv4' option to the 'curl' command. It's turned off by default. To enable
+
+    let g:vrc_resolve_to_ipv4 = 1
+
 #### `vrc_set_default_mapping`
 
 This option is to enable/disable the trigger key mapping. It's enabled by

--- a/doc/vim-rest-console.txt
+++ b/doc/vim-rest-console.txt
@@ -34,6 +34,7 @@ CONTENTS                                                         *VrcContents*
       vrc_include_response_header.............. |vrc_include_response_header|
       vrc_max_time............................................ |vrc_max_time|
       vrc_output_buffer_name........................ |vrc_output_buffer_name|
+      vrc_resolve_to_ipv4.............................. |vrc_resolve_to_ipv4|
       vrc_set_default_mapping...................... |vrc_set_default_mapping|
       vrc_show_command.....................................|vrc_show_command|
       vrc_split_request_body........................ |vrc_split_request_body|
@@ -461,6 +462,15 @@ its own output display. For this, the option can be set in the buffer scope as
 >
     let b:vrc_output_buffer_name = '__REST_1_OUTPUT__'
 <
+------------------------------------------------------------------------------
+*vrc_resolve_to_ipv4*
+
+This option forces names to be resolved to IPV4 addresses only by adding the
+'--ipv4' option to the 'curl' command. It's turned off by default. To enable
+>
+    let g:vrc_resolve_to_ipv4 = 1
+<
+
 ------------------------------------------------------------------------------
 *vrc_set_default_mapping*
 

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -290,6 +290,12 @@ function! s:GetCurlCommand(request)
         call add(curlArgs, '-k')
     endif
 
+    """ Add --ipv4
+    let resolveToIpv4 = s:GetOptValue('vrc_resolve_to_ipv4', 0)
+    if resolveToIpv4
+        call add(curlArgs, '--ipv4')
+    endif
+
     """ Add --cookie-jar
     let cookieJar = s:GetOptValue('vrc_cookie_jar', 0)
     if !empty(cookieJar)


### PR DESCRIPTION
This PR adds a new option to the plugin: vrc_resolve_to_ipv4, that when set forces curl to resolve names to IPV4 addresses.