### PR TITLE
Make comment highlight works at end of line

### DIFF
--- a/syntax/rest.vim
+++ b/syntax/rest.vim
@@ -77,7 +77,7 @@ highlight link restHost Label
 syntax match restKeyword '\c\v^\s*(GET|POST|PUT|DELETE|HEAD|PATCH|OPTIONS|TRACE)\s'
 highlight link restKeyword Macro
 
-syntax match restComment '\v^\s*(#|//).*$'
+syntax match restComment '\v\s*(#|//).*$'
 highlight link restComment Comment
 
 


### PR DESCRIPTION
For following case, make the comment hightlight also works

```
GET /dump_consensus_state  # this is comment
```