### PR TITLE
bugfix: StrTrim did not work when string has only one char

### DIFF
--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -28,7 +28,7 @@ let s:deprecatedCurlOpts = {
 " @return string
 "
 function! s:StrTrim(txt)
-  return substitute(a:txt, '\v^\s*([^[:space:]].*[^[:space:]])\s*$', '\1', 'g')
+  return substitute(a:txt, '\v^\s*(\S(.*\S)*)\s*$', '\1', 'g')
 endfunction
 
 """


### PR DESCRIPTION
For example, following global variable `cnt` will be recognised as `_1` (_ represent space):

```
# host: node1
http://localhost:46669
cnt = 1
--
```