### PR TITLE
Body preprocessor option

### DIFF
--- a/doc/vim-rest-console.txt
+++ b/doc/vim-rest-console.txt
@@ -464,6 +464,18 @@ If set, VRC will try to transform all unicode `\uXXXX` instances in the
 response to the corresponding symbols. It's turned of by default.
 
 ------------------------------------------------------------------------------
+*vrc_body_preprocessor*
+
+An external command to run using the request body as input, the output of
+which will then be used as the body for the request. Default is an empty
+string, which will not run any preprocessing.
+
+Example using yaml2json to convert from yaml (easier to type) to JSON,
+and then piping into jq minify that:
+>
+    let g:vrc_body_preprocessor = 'yaml2json | jq -c .'
+<
+------------------------------------------------------------------------------
 *vrc_curl_opts*
 
 A dictionary that contains the default cUrl options. Default: not exist.

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -517,11 +517,7 @@ function! s:GetCurlDataArgs(request)
   let httpVerb = a:request.httpVerb
   let dataLines = a:request.dataBody
 
-  """ Call body preprocessor if set.
   let preproc = s:GetOpt('vrc_body_preprocessor', '')
-  if preproc != ''
-      let dataLines = systemlist(preproc, join(a:request.dataBody, "\r"))
-  endif
 
   """ These verbs should have request body passed as POST params.
   if httpVerb ==? 'POST'
@@ -531,6 +527,11 @@ function! s:GetCurlDataArgs(request)
     """ If data is loaded from file.
     if stridx(get(dataLines, 0, ''), '@') == 0
       return '--data-binary ' . shellescape(dataLines[0])
+    endif
+
+    """ Call body preprocessor if set.
+    if preproc != ''
+      let dataLines = systemlist(preproc, join(dataLines, "\r"))
     endif
 
     """ If request body is split line by line.
@@ -558,6 +559,10 @@ function! s:GetCurlDataArgs(request)
 
   """ If verb is GET and GET request body is allowed.
   if httpVerb ==? 'GET' && s:GetOpt('vrc_allow_get_request_body', 0)
+    """ Call body preprocessor if set.
+    if preproc != ''
+      let dataLines = systemlist(preproc, join(dataLines, "\r"))
+    endif
     return '--data ' . shellescape(join(dataLines, ''))
   endif
 

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -517,6 +517,12 @@ function! s:GetCurlDataArgs(request)
   let httpVerb = a:request.httpVerb
   let dataLines = a:request.dataBody
 
+  """ Call body preprocessor if set.
+  let preproc = s:GetOpt('vrc_body_preprocessor', '')
+  if preproc != ''
+      let dataLines = systemlist(preproc, join(a:request.dataBody, "\r"))
+  endif
+
   """ These verbs should have request body passed as POST params.
   if httpVerb ==? 'POST'
     \ || httpVerb ==? 'PUT'

--- a/syntax/rest.vim
+++ b/syntax/rest.vim
@@ -2,74 +2,224 @@ if exists('b:current_syntax')
     finish
 endif
 
-syntax match   jsonNoise           /\%(:\|,\)/
-
-" Syntax: Strings
-" Separated into a match and region because a region by itself is always greedy
-syn match  jsonStringMatch /"\([^"]\|\\\"\)\+"\ze[[:blank:]\r\n]*[,}\]]/ contains=jsonString
-syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ contains=jsonEscape contained
-
-" Syntax: JSON does not allow strings with single quotes, unlike JavaScript.
-syn region  jsonStringSQError oneline  start=+'+  skip=+\\\\\|\\"+  end=+'+
-
-" Syntax: JSON Keywords
-" Separated into a match and region because a region by itself is always greedy
-syn match  jsonKeywordMatch /"\([^"]\|\\\"\)\+"[[:blank:]\r\n]*\:/ contains=jsonKeyword
-syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ contains=jsonEscape contained
-
-" Syntax: Escape sequences
-syn match   jsonEscape    "\\["\\/bfnrt]" contained
-syn match   jsonEscape    "\\u\x\{4}" contained
-
-" Syntax: Numbers
-syn match   jsonNumber    "-\=\<\%(0\|[1-9]\d*\)\%(\.\d\+\)\=\%([eE][-+]\=\d\+\)\=\>\ze[[:blank:]\r\n]*[,}\]]"
-
-" ERROR WARNINGS **********************************************
-" Syntax: No trailing comma after the last element of arrays or objects
-syn match   jsonTrailingCommaError  ",\_s*[}\]]"
-
-" Syntax: Watch out for missing commas between elements
-syn match   jsonMissingCommaError /\("\|\]\|\d\)\zs\_s\+\ze"/
-syn match   jsonMissingCommaError /\(\]\|\}\)\_s\+\ze"/ "arrays/objects as values
-syn match   jsonMissingCommaError /}\_s\+\ze{/ "objects as elements in an array
-syn match   jsonMissingCommaError /\(true\|false\)\_s\+\ze"/ "true/false as value
-
-" ********************************************** END OF ERROR WARNINGS
-" Allowances for JSONP: function call at the beginning of the file,
-" parenthesis and semicolon at the end.
-" Function name validation based on
-" http://stackoverflow.com/questions/2008279/validate-a-javascript-function-name/2008444#2008444
-syn match  jsonPadding "\%^[[:blank:]\r\n]*[_$[:alpha:]][_$[:alnum:]]*[[:blank:]\r\n]*("
-syn match  jsonPadding ");[[:blank:]\r\n]*\%$"
-
-" Syntax: Boolean
-syn match  jsonBoolean /\(true\|false\)\(\_s\+\ze"\)\@!/
-
-" Syntax: Null
-syn keyword  jsonNull      null
-
-" Syntax: Braces
-syn region  jsonFold matchgroup=jsonBraces start="{" end=/}\(\_s\+\ze\("\|{\)\)\@!/ transparent fold
-syn region  jsonFold matchgroup=jsonBraces start="\[" end=/]\(\_s\+\ze"\)\@!/ transparent fold
-
-" Define the default highlighting.
-if version >= 508 || !exists("did_json_syn_inits")
-  hi def link jsonPadding		Operator
-  hi def link jsonString		String
-  hi def link jsonTest			Label
-  hi def link jsonEscape		Special
-  hi def link jsonNumber		Delimiter
-  hi def link jsonBraces		Delimiter
-  hi def link jsonNull			Function
-  hi def link jsonBoolean		Delimiter
-  hi def link jsonKeyword		Label
-
-  hi def link jsonTrailingCommaError		Error
-  hi def link jsonMissingCommaError		Error
-
-  hi def link jsonQuote			Quote
-  hi def link jsonNoise			Noise
+if !exists('b:yaml_schema')
+  if exists('g:yaml_schema')
+    let b:yaml_schema = g:yaml_schema
+  else
+    let b:yaml_schema = 'core'
+  endif
 endif
+
+let s:ns_char = '\%([\n\r\uFEFF \t]\@!\p\)'
+let s:ns_word_char = '[[:alnum:]_\-]'
+let s:ns_uri_char  = '\%(%\x\x\|'.s:ns_word_char.'\|[#/;?:@&=+$,.!~*''()[\]]\)'
+let s:ns_tag_char  = '\%(%\x\x\|'.s:ns_word_char.'\|[#/;?:@&=+$.~*''()]\)'
+let s:c_ns_anchor_char = '\%([\n\r\uFEFF \t,[\]{}]\@!\p\)'
+let s:c_indicator      = '[\-?:,[\]{}#&*!|>''"%@`]'
+let s:c_flow_indicator = '[,[\]{}]'
+
+let s:ns_char_without_c_indicator = substitute(s:ns_char, '\v\C[\zs', '\=s:c_indicator[1:-2]', '')
+
+let s:_collection = '[^\@!\(\%(\\\.\|\[^\\\]]\)\+\)]'
+let s:_neg_collection = '[^\(\%(\\\.\|\[^\\\]]\)\+\)]'
+function s:SimplifyToAssumeAllPrintable(p)
+    return substitute(a:p, '\V\C\\%('.s:_collection.'\\@!\\p\\)', '[^\1]', '')
+endfunction
+let s:ns_char = s:SimplifyToAssumeAllPrintable(s:ns_char)
+let s:ns_char_without_c_indicator = s:SimplifyToAssumeAllPrintable(s:ns_char_without_c_indicator)
+let s:c_ns_anchor_char = s:SimplifyToAssumeAllPrintable(s:c_ns_anchor_char)
+
+function s:SimplifyAdjacentCollections(p)
+    return substitute(a:p, '\V\C'.s:_collection.'\\|'.s:_collection, '[\1\2]', 'g')
+endfunction
+let s:ns_uri_char = s:SimplifyAdjacentCollections(s:ns_uri_char)
+let s:ns_tag_char = s:SimplifyAdjacentCollections(s:ns_tag_char)
+
+let s:c_verbatim_tag = '!<'.s:ns_uri_char.'\+>'
+let s:c_named_tag_handle     = '!'.s:ns_word_char.'\+!'
+let s:c_secondary_tag_handle = '!!'
+let s:c_primary_tag_handle   = '!'
+let s:c_tag_handle = '\%('.s:c_named_tag_handle.
+            \         '\|'.s:c_secondary_tag_handle.
+            \         '\|'.s:c_primary_tag_handle.'\)'
+let s:c_ns_shorthand_tag = s:c_tag_handle . s:ns_tag_char.'\+'
+let s:c_non_specific_tag = '!'
+let s:c_ns_tag_property = s:c_verbatim_tag.
+            \        '\|'.s:c_ns_shorthand_tag.
+            \        '\|'.s:c_non_specific_tag
+
+let s:c_ns_anchor_name = s:c_ns_anchor_char.'\+'
+let s:c_ns_anchor_property =  '&'.s:c_ns_anchor_name
+let s:c_ns_alias_node      = '\*'.s:c_ns_anchor_name
+
+let s:ns_directive_name = s:ns_char.'\+'
+
+let s:ns_local_tag_prefix  = '!'.s:ns_uri_char.'*'
+let s:ns_global_tag_prefix = s:ns_tag_char.s:ns_uri_char.'*'
+let s:ns_tag_prefix = s:ns_local_tag_prefix.
+            \    '\|'.s:ns_global_tag_prefix
+
+let s:ns_plain_safe_out = s:ns_char
+let s:ns_plain_safe_in  = '\%('.s:c_flow_indicator.'\@!'.s:ns_char.'\)'
+
+let s:ns_plain_safe_in = substitute(s:ns_plain_safe_in, '\V\C\\%('.s:_collection.'\\@!'.s:_neg_collection.'\\)', '[^\1\2]', '')
+let s:ns_plain_safe_in_without_colhash = substitute(s:ns_plain_safe_in, '\V\C'.s:_neg_collection, '[^\1:#]', '')
+let s:ns_plain_safe_out_without_colhash = substitute(s:ns_plain_safe_out, '\V\C'.s:_neg_collection, '[^\1:#]', '')
+
+let s:ns_plain_first_in  = '\%('.s:ns_char_without_c_indicator.'\|[?:\-]\%('.s:ns_plain_safe_in.'\)\@=\)'
+let s:ns_plain_first_out = '\%('.s:ns_char_without_c_indicator.'\|[?:\-]\%('.s:ns_plain_safe_out.'\)\@=\)'
+
+let s:ns_plain_char_in  = '\%('.s:ns_char.'#\|:'.s:ns_plain_safe_in.'\|'.s:ns_plain_safe_in_without_colhash.'\)'
+let s:ns_plain_char_out = '\%('.s:ns_char.'#\|:'.s:ns_plain_safe_out.'\|'.s:ns_plain_safe_out_without_colhash.'\)'
+
+let s:ns_plain_out = s:ns_plain_first_out . s:ns_plain_char_out.'*'
+let s:ns_plain_in  = s:ns_plain_first_in  . s:ns_plain_char_in.'*'
+
+
+syn keyword yamlTodo            contained TODO FIXME XXX NOTE
+
+syn region  yamlComment         display oneline start='\%\(^\|\s\)#' end='$'
+            \                   contains=yamlTodo
+
+execute 'syn region yamlDirective oneline start='.string('^\ze%'.s:ns_directive_name.'\s\+').' '.
+            \                            'end="$" '.
+            \                            'contains=yamlTAGDirective,'.
+            \                                     'yamlYAMLDirective,'.
+            \                                     'yamlReservedDirective '.
+            \                            'keepend'
+
+syn match yamlTAGDirective '%TAG\s\+' contained nextgroup=yamlTagHandle
+execute 'syn match yamlTagHandle contained nextgroup=yamlTagPrefix '.string(s:c_tag_handle.'\s\+')
+execute 'syn match yamlTagPrefix contained nextgroup=yamlComment ' . string(s:ns_tag_prefix)
+
+syn match yamlYAMLDirective '%YAML\s\+'  contained nextgroup=yamlYAMLVersion
+syn match yamlYAMLVersion   '\d\+\.\d\+' contained nextgroup=yamlComment
+
+execute 'syn match yamlReservedDirective contained nextgroup=yamlComment '.
+            \string('%\%(\%(TAG\|YAML\)\s\)\@!'.s:ns_directive_name)
+
+syn region yamlFlowString matchgroup=yamlFlowStringDelimiter start='"' skip='\\"' end='"'
+            \ contains=yamlEscape
+            \ nextgroup=yamlKeyValueDelimiter
+syn region yamlFlowString matchgroup=yamlFlowStringDelimiter start="'" skip="''"  end="'"
+            \ contains=yamlSingleEscape
+            \ nextgroup=yamlKeyValueDelimiter
+syn match  yamlEscape contained '\\\%([\\"abefnrtv\^0_ NLP\n]\|x\x\x\|u\x\{4}\|U\x\{8}\)'
+syn match  yamlSingleEscape contained "''"
+
+syn match yamlBlockScalarHeader contained '\s\+\zs[|>]\%([+-]\=[1-9]\|[1-9]\=[+-]\)\='
+
+syn cluster yamlConstant contains=yamlBool,yamlNull
+
+syn cluster yamlFlow contains=yamlFlowString,yamlFlowMapping,yamlFlowCollection
+syn cluster yamlFlow      add=yamlFlowMappingKey,yamlFlowMappingMerge
+syn cluster yamlFlow      add=@yamlConstant,yamlPlainScalar,yamlFloat
+syn cluster yamlFlow      add=yamlTimestamp,yamlInteger,yamlMappingKeyStart
+syn cluster yamlFlow      add=yamlComment
+syn region yamlFlowMapping    matchgroup=yamlFlowIndicator start='{' end='}' contains=@yamlFlow
+syn region yamlFlowCollection matchgroup=yamlFlowIndicator start='\[' end='\]' contains=@yamlFlow
+
+execute 'syn match yamlPlainScalar /'.s:ns_plain_out.'/'
+execute 'syn match yamlPlainScalar contained /'.s:ns_plain_in.'/'
+
+syn match yamlMappingKeyStart '?\ze\s'
+syn match yamlMappingKeyStart '?' contained
+
+execute 'syn match yamlFlowMappingKey /\%#=1'.s:ns_plain_in.'\%(\s\+'.s:ns_plain_in.'\)*\ze\s*:/ contained '.
+            \'nextgroup=yamlKeyValueDelimiter'
+syn match yamlFlowMappingMerge /<<\ze\s*:/ contained nextgroup=yamlKeyValueDelimiter
+
+syn match yamlBlockCollectionItemStart '^\s*\zs-\%(\s\+-\)*\s' nextgroup=yamlBlockMappingKey,yamlBlockMappingMerge
+" Use the old regexp engine, the NFA engine doesn't like all the \@ items.
+execute 'syn match yamlBlockMappingKey /\%#=1^\s*\zs'.s:ns_plain_out.'\%(\s\+'.s:ns_plain_out.'\)*\ze\s*:\%(\s\|$\)/ '.
+            \'nextgroup=yamlKeyValueDelimiter'
+execute 'syn match yamlBlockMappingKey /\%#=1\s*\zs'.s:ns_plain_out.'\%(\s\+'.s:ns_plain_out.'\)*\ze\s*:\%(\s\|$\)/ contained '.
+            \'nextgroup=yamlKeyValueDelimiter'
+syn match yamlBlockMappingMerge /^\s*\zs<<\ze:\%(\s\|$\)/ nextgroup=yamlKeyValueDelimiter
+syn match yamlBlockMappingMerge /<<\ze\s*:\%(\s\|$\)/ nextgroup=yamlKeyValueDelimiter contained
+
+syn match   yamlKeyValueDelimiter /\s*:/ contained
+syn match   yamlKeyValueDelimiter /\s*:/ contained
+
+syn cluster yamlScalarWithSpecials contains=yamlPlainScalar,yamlBlockMappingKey,yamlFlowMappingKey
+
+let s:_bounder = s:SimplifyToAssumeAllPrintable('\%([[\]{}, \t]\@!\p\)')
+if b:yaml_schema is# 'json'
+    syn keyword yamlNull null contained containedin=@yamlScalarWithSpecials
+    syn keyword yamlBool true false
+    exe 'syn match   yamlInteger /'.s:_bounder.'\@1<!\%(0\|-\=[1-9][0-9]*\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match   yamlFloat   /'.s:_bounder.'\@1<!\%(-\=[1-9][0-9]*\%(\.[0-9]*\)\=\(e[-+]\=[0-9]\+\)\=\|0\|-\=\.inf\|\.nan\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+elseif b:yaml_schema is# 'core'
+    syn keyword yamlNull null Null NULL contained containedin=@yamlScalarWithSpecials
+    syn keyword yamlBool true True TRUE false False FALSE contained containedin=@yamlScalarWithSpecials
+    exe 'syn match   yamlNull /'.s:_bounder.'\@1<!\~'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match   yamlInteger /'.s:_bounder.'\@1<!\%([+-]\=\%(0\%(b[0-1_]\+\|[0-7_]\+\|x[0-9a-fA-F_]\+\)\=\|\%([1-9][0-9_]*\%(:[0-5]\=\d\)\+\)\)\|[1-9][0-9_]*\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match   yamlFloat /'.s:_bounder.'\@1<!\%([+-]\=\%(\%(\d[0-9_]*\)\.[0-9_]*\%([eE][+-]\=\d\+\)\=\|\.[0-9_]\+\%([eE][-+]\=[0-9]\+\)\=\|\d[0-9_]*\%(:[0-5]\=\d\)\+\.[0-9_]*\|\.\%(inf\|Inf\|INF\)\)\|\%(\.\%(nan\|NaN\|NAN\)\)\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+elseif b:yaml_schema is# 'pyyaml'
+    syn keyword yamlNull null Null NULL contained containedin=@yamlScalarWithSpecials
+    syn keyword yamlBool true True TRUE false False FALSE yes Yes YES no No NO on On ON off Off OFF contained containedin=@yamlScalarWithSpecials
+    exe 'syn match   yamlNull /'.s:_bounder.'\@1<!\~'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match  yamlFloat /'.s:_bounder.'\@1<!\%(\v[-+]?%(\d[0-9_]*)\.[0-9_]*%([eE][-+]\d+)?|\.[0-9_]+%([eE][-+]\d+)?|[-+]?\d[0-9_]*%(\:[0-5]?\d)+\.[0-9_]*|[-+]?\.%(inf|Inf|INF)|\.%(nan|NaN|NAN)\m\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match  yamlInteger /'.s:_bounder.'\@1<!\%(\v[-+]?0b[0-1_]+|[-+]?0[0-7_]+|[-+]?%(0|[1-9][0-9_]*)|[-+]?0x[0-9a-fA-F_]+|[-+]?[1-9][0-9_]*%(:[0-5]?\d)+\m\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match  yamlTimestamp /'.s:_bounder.'\@1<!\%(\v\d\d\d\d\-\d\d\-\d\d|\d\d\d\d \-\d\d? \-\d\d?%([Tt]|[ \t]+)\d\d?\:\d\d \:\d\d %(\.\d*)?%([ \t]*%(Z|[-+]\d\d?%(\:\d\d)?))?\m\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+elseif b:yaml_schema is# 'failsafe'
+    " Nothing
+endif
+unlet s:_bounder
+
+
+execute 'syn match yamlNodeTag '.string(s:c_ns_tag_property)
+execute 'syn match yamlAnchor  '.string(s:c_ns_anchor_property)
+execute 'syn match yamlAlias   '.string(s:c_ns_alias_node)
+
+syn match yamlDocumentStart '^---\ze\%(\s\|$\)'
+syn match yamlDocumentEnd   '^\.\.\.\ze\%(\s\|$\)'
+
+hi def link yamlTodo                     Todo
+hi def link yamlComment                  Comment
+
+hi def link yamlDocumentStart            PreProc
+hi def link yamlDocumentEnd              PreProc
+
+hi def link yamlDirectiveName            Keyword
+
+hi def link yamlTAGDirective             yamlDirectiveName
+hi def link yamlTagHandle                String
+hi def link yamlTagPrefix                String
+
+hi def link yamlYAMLDirective            yamlDirectiveName
+hi def link yamlReservedDirective        Error
+hi def link yamlYAMLVersion              Number
+
+hi def link yamlString                   String
+hi def link yamlFlowString               yamlString
+hi def link yamlFlowStringDelimiter      yamlString
+hi def link yamlEscape                   SpecialChar
+hi def link yamlSingleEscape             SpecialChar
+
+hi def link yamlBlockCollectionItemStart Label
+hi def link yamlBlockMappingKey          Identifier
+hi def link yamlBlockMappingMerge        Special
+
+hi def link yamlFlowMappingKey           Identifier
+hi def link yamlFlowMappingMerge         Special
+
+hi def link yamlMappingKeyStart          Special
+hi def link yamlFlowIndicator            Special
+hi def link yamlKeyValueDelimiter        Special
+
+hi def link yamlConstant                 Constant
+
+hi def link yamlNull                     yamlConstant
+hi def link yamlBool                     yamlConstant
+
+hi def link yamlAnchor                   Type
+hi def link yamlAlias                    Type
+hi def link yamlNodeTag                  Type
+
+hi def link yamlInteger                  Number
+hi def link yamlFloat                    Float
+hi def link yamlTimestamp                Number
 
 syntax match restHost '\c\v^\s*HTTPS?\://\S+$'
 highlight link restHost Label

--- a/syntax/rest.vim
+++ b/syntax/rest.vim
@@ -22,14 +22,14 @@ let s:ns_char_without_c_indicator = substitute(s:ns_char, '\v\C[\zs', '\=s:c_ind
 
 let s:_collection = '[^\@!\(\%(\\\.\|\[^\\\]]\)\+\)]'
 let s:_neg_collection = '[^\(\%(\\\.\|\[^\\\]]\)\+\)]'
-function s:SimplifyToAssumeAllPrintable(p)
+function! s:SimplifyToAssumeAllPrintable(p)
     return substitute(a:p, '\V\C\\%('.s:_collection.'\\@!\\p\\)', '[^\1]', '')
 endfunction
 let s:ns_char = s:SimplifyToAssumeAllPrintable(s:ns_char)
 let s:ns_char_without_c_indicator = s:SimplifyToAssumeAllPrintable(s:ns_char_without_c_indicator)
 let s:c_ns_anchor_char = s:SimplifyToAssumeAllPrintable(s:c_ns_anchor_char)
 
-function s:SimplifyAdjacentCollections(p)
+function! s:SimplifyAdjacentCollections(p)
     return substitute(a:p, '\V\C'.s:_collection.'\\|'.s:_collection, '[\1\2]', 'g')
 endfunction
 let s:ns_uri_char = s:SimplifyAdjacentCollections(s:ns_uri_char)


### PR DESCRIPTION
This PR adds a `vrc_body_preprocessor` option, which pipes a request body into an external program before sending it in a request.
Use case: I prefer to type yaml, as it requires many fewer characters than JSON, and convert it to JSON to send in requests. I would assume others may appreciate this feature.

~~Would be nice to do, maybe I can add later: syntax highlighting for different body syntaxes.~~
yaml syntax added. Conveniently, json is a subset of yaml so it should appropriately highlight all.