### PR TITLE
Don't pass curl opts as headers

### DIFF
--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -190,7 +190,7 @@ function! s:ParseHeaders(start, end)
   let hasContentType = 0
   for line in lineBuf
     let line = s:StrTrim(line)
-    if line ==? '' || line =~? s:vrc_comment_delim
+    if line ==? '' || line =~? s:vrc_comment_delim || line =~? '\v^--?\w+'
       continue
     endif
     let sepIdx = stridx(line, ':')


### PR DESCRIPTION
Fixes a bug that would send curl options containing a colon as additional headers

Resolves #60 