### PR TITLE
Use black hole register when deleting output buffer

### DIFF
--- a/doc/vim-rest-console.txt
+++ b/doc/vim-rest-console.txt
@@ -32,6 +32,7 @@ CONTENTS                                                         *VrcContents*
       vrc_curl_opts.......................................... |vrc_curl_opts|
       vrc_debug.................................................. |vrc_debug|
       vrc_elasticsearch_support.................. |vrc_elasticsearch_support|
+      vrc_flex_columns.................................... |vrc_flex_columns|
       vrc_header_content_type...................... |vrc_header_content_type|
       vrc_horizontal_split............................ |vrc_horizontal_split|
       vrc_keepalt.............................................. |vrc_keepalt|
@@ -502,6 +503,13 @@ default.
 If enabled, the data of Elasticsearch's `_bulk` API can also be specified
 directly in the request block instead of indirectly via an external file.
 It's off by default.
+
+------------------------------------------------------------------------------
+*vrc_flex_columns*
+
+A number, that decides if the ouptut buffer is a vertical or horizontal
+split, if you define |vrc_horizontal_split|, this option doesn't work.
+It's 155 by default.
 
 ------------------------------------------------------------------------------
 *vrc_header_content_type*

--- a/doc/vim-rest-console.txt
+++ b/doc/vim-rest-console.txt
@@ -586,6 +586,14 @@ list. It's enabled by default. To disable:
     let g:vrc_show_command_in_quickfix = 0
 
 ------------------------------------------------------------------------------
+*vrc_curl_timeout*
+
+Kill curl after this timeout - default 1m.
+See man timeout for details.
+>
+    let g:vrc_curl_timeout = '5s'
+
+------------------------------------------------------------------------------
 *vrc_show_command_in_result_buffer*
 
 This option enables the printing of the executed curl command in the output

--- a/doc/vim-rest-console.txt
+++ b/doc/vim-rest-console.txt
@@ -39,6 +39,8 @@ CONTENTS                                                         *VrcContents*
       vrc_response_default_content_type.. |vrc_response_default_content_type|
       vrc_set_default_mapping...................... |vrc_set_default_mapping|
       vrc_show_command.....................................|vrc_show_command|
+      vrc_show_command_in_quickfix.............|vrc_show_command_in_quickfix|
+      vrc_show_command_in_result_buffer...|vrc_show_command_in_result_buffer|
       vrc_split_request_body........................ |vrc_split_request_body|
       vrc_syntax_highlight_response...........|vrc_syntax_highlight_response|
       vrc_trigger.............................................. |vrc_trigger|
@@ -575,6 +577,21 @@ pane. It's disabled by default. To enable:
 >
     let g:vrc_show_command = 1
 <
+------------------------------------------------------------------------------
+*vrc_show_command_in_quickfix*
+
+This option disables the printing of the executed curl command in the quickfix 
+list. It's enabled by default. To disable:
+>
+    let g:vrc_show_command_in_quickfix = 0
+
+------------------------------------------------------------------------------
+*vrc_show_command_in_result_buffer*
+
+This option enables the printing of the executed curl command in the output
+pane. It's disabled by default. To enable:
+>
+    let g:vrc_show_command_in_result_buffer = 1
 ------------------------------------------------------------------------------
 *vrc_split_request_body*
 

--- a/doc/vim-rest-console.txt
+++ b/doc/vim-rest-console.txt
@@ -27,22 +27,22 @@ CONTENTS                                                         *VrcContents*
   6. Configuration........................................ |VrcConfiguration|
       vrc_allow_get_request_body................ |vrc_allow_get_request_body|
       vrc_auto_format_response_enabled.... |vrc_auto_format_response_enabled|
-      vrc_auto_format_response_patterns...|vrc_auto_format_response_patterns|
-      vrc_auto_format_uhex.............................|vrc_auto_format_uhex|
+      vrc_auto_format_response_patterns.. |vrc_auto_format_response_patterns|
+      vrc_auto_format_uhex............................ |vrc_auto_format_uhex|
       vrc_curl_opts.......................................... |vrc_curl_opts|
       vrc_debug.................................................. |vrc_debug|
       vrc_elasticsearch_support.................. |vrc_elasticsearch_support|
       vrc_header_content_type...................... |vrc_header_content_type|
-      vrc_horizontal_split.....   .................... |vrc_horizontal_split|
+      vrc_horizontal_split............................ |vrc_horizontal_split|
       vrc_keepalt.............................................. |vrc_keepalt|
       vrc_output_buffer_name........................ |vrc_output_buffer_name|
       vrc_response_default_content_type.. |vrc_response_default_content_type|
       vrc_set_default_mapping...................... |vrc_set_default_mapping|
-      vrc_show_command.....................................|vrc_show_command|
-      vrc_show_command_in_quickfix.............|vrc_show_command_in_quickfix|
-      vrc_show_command_in_result_buffer...|vrc_show_command_in_result_buffer|
+      vrc_show_command.................................... |vrc_show_command|
+      vrc_show_command_in_quickfix............ |vrc_show_command_in_quickfix|
+      vrc_show_command_in_result_buffer.. |vrc_show_command_in_result_buffer|
       vrc_split_request_body........................ |vrc_split_request_body|
-      vrc_syntax_highlight_response...........|vrc_syntax_highlight_response|
+      vrc_syntax_highlight_response.......... |vrc_syntax_highlight_response|
       vrc_trigger.............................................. |vrc_trigger|
   7. Tips 'n Tricks................................................. |VrcTnt|
       7.1 POST Data in Bulk................................. |VrcTntDataBulk|

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -640,10 +640,12 @@ function! s:DisplayOutput(tmpBufName, outputInfo, config)
   call setline('.', split(substitute(output, '[[:return:]]', '', 'g'), '\v\n'))
 
   """ Display commands in quickfix window if any.
-  if (!empty(a:outputInfo['commands']))
-    execute 'cgetexpr' string(a:outputInfo['commands'])
-    copen
-    execute outputWin 'wincmd w'
+  if s:GetOpt('vrc_show_command_in_quickfix', 1)
+    if (!empty(a:outputInfo['commands']))
+      execute 'cgetexpr' string(a:outputInfo['commands'])
+      copen
+      execute outputWin 'wincmd w'
+    endif
   endif
 
   """ Detect content-type based on the returned header.
@@ -702,6 +704,15 @@ function! s:DisplayOutput(tmpBufName, outputInfo, config)
         execute "syntax region body start=/^$/ end=/\%$/ contains=@vrc_" . fileType
       catch
       endtry
+    endif
+  endif
+
+  """ Display commands in result buffer if any.
+  if s:GetOpt('vrc_show_command_in_result_buffer', 0)
+    if (!empty(a:outputInfo['commands']))
+      let prefixedList = map(copy(a:outputInfo['commands']), '"REQUEST: " . v:val . "\t"') 
+      call append(0, prefixedList)
+      call append(1, '')
     endif
   endif
 

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -742,7 +742,7 @@ function! s:DisplayOutput(tmpBufName, outputInfo, config)
   execute '1delete _'
   " WTF:
   call timer_start(10, { tid -> execute('normal "_ddu')})
-  call timer_start(20, { tid -> execute('normal GzxggzMzr')})
+  call timer_start(20, { tid -> execute('normal GzxggzMzrzr')})
   " call timer_start(50, { tid -> execute('setlocal nomodifiable')})
   call timer_start(100, { tid -> execute(origWin . 'wincmd w')})
 endfunction

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -190,11 +190,18 @@ endfunction
 "
 " @param  int  a:start
 " @param  int  a:end
+" @param  bool a:hasBody
 " @return dict {'header1': 'value1', 'header2': 'value2'}
 "
-function! s:ParseHeaders(start, end)
+function! s:ParseHeaders(start, end, hasBody)
   let contentTypeOpt = s:GetOpt('vrc_header_content_type', 'application/json')
-  let headers = {'Content-Type': contentTypeOpt}
+
+  let headers = {}
+
+  if a:hasBody
+    let headers = {'Content-Type': contentTypeOpt}
+  endif
+
   if (a:end < a:start)
     return headers
   endif
@@ -272,7 +279,7 @@ function! s:ParseGlobSection()
   let [hostLine, host] = s:ParseHost(1, lastLine - 1)
 
   """ Parse global headers.
-  let headers = s:ParseHeaders(hostLine + 1, lastLine - 1)
+  let headers = s:ParseHeaders(hostLine + 1, lastLine - 1, v:false)
 
   """ Parse curl options.
   let curlOpts = s:ParseCurlOpts(hostLine + 1, lastLine - 1)
@@ -365,7 +372,8 @@ function! s:ParseRequest(start, resumeFrom, end, globSection)
   endif
 
   """ Parse headers if any and merge with global headers.
-  let localHeaders = s:ParseHeaders(lineNumHost + 1, lineNumVerb - 1)
+  let hasBody = !empty(getline(lineNumVerb + 1, lineNumNextVerb - 1))
+  let localHeaders = s:ParseHeaders(lineNumHost + 1, lineNumVerb - 1, hasBody)
   let headers = get(a:globSection, 'headers', {})
   call extend(headers, localHeaders)
 

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -635,7 +635,7 @@ function! s:DisplayOutput(tmpBufName, outputInfo, config)
 
   """ Display output in view.
   setlocal modifiable
-  silent! normal! ggdG
+  silent! normal! gg"_dG
   let output = join(a:outputInfo['outputChunks'], "\n\n")
   call setline('.', split(substitute(output, '[[:return:]]', '', 'g'), '\v\n'))
 

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -843,9 +843,9 @@ endfunction
 "
 function! VrcMap()
   let triggerKey = s:GetOpt('vrc_trigger', '<C-j>')
-  execute 'vnoremap <buffer> ' . triggerKey . ' :call VrcQuery()<CR>'
+  " execute 'vnoremap <buffer> ' . triggerKey . ' :call VrcQuery()<CR>'
   execute 'nnoremap <buffer> ' . triggerKey . ' :call VrcQuery()<CR>'
-  execute 'inoremap <buffer> ' . triggerKey . ' <Esc>:call VrcQuery()<CR>'
+  " execute 'inoremap <buffer> ' . triggerKey . ' <Esc>:call VrcQuery()<CR>'
 endfunction
 
 if s:GetOpt('vrc_set_default_mapping', 1)

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -753,14 +753,13 @@ function! s:DisplayOutput(tmpBufName, outputInfo, config)
   endif
 
   " WTF:
-  call timer_start(10, { tid -> execute('normal "_ddu')})
   if includeResponseHeader
-    call timer_start(30, { tid -> execute('normal GzxggzMzrzrza')})
+    call timer_start(10, { tid -> execute('setlocal foldlevel=2 | normal zxggza)jzv')})
   else
-    call timer_start(30, { tid -> execute('normal GzxggzMzr')})
+    call timer_start(10, { tid -> execute('setlocal foldlevel=1 | normal zxzr')})
   endif
-  call timer_start(150, { tid -> execute('setlocal nomodifiable')})
-  call timer_start(250, { tid -> execute(origWin . 'wincmd w')})
+  call timer_start(30, { tid -> execute('setlocal nomodifiable')})
+  call timer_start(40, { tid -> execute(origWin . 'wincmd w')})
 endfunction
 
 """

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -632,9 +632,14 @@ function! s:DisplayOutput(tmpBufName, outputInfo, config)
     "" Open in Split Window
     let outputWin = bufwinnr(bufnr(a:tmpBufName))
     if outputWin == -1
-      let cmdSplit = 'vsplit'
       if s:GetOpt('vrc_horizontal_split', 0)
         let cmdSplit = 'split'
+      else
+        if &columns <= 120
+          let cmdSplit = 'split'
+        else
+          let cmdSplit = 'vsplit'
+        endif
       endif
 
       if s:GetOpt('vrc_keepalt', 0)

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -502,7 +502,7 @@ function! s:GetCurlCommand(request)
   endif
   let vrcCurlTimeout = s:GetOpt('vrc_curl_timeout', '1m')
   return [
-    \ 'timeout ' . vrcCurlTimeout . ' curl ' . join(curlArgs) . ' ' . s:Shellescape(a:request.host . a:request.requestPath),
+    \ 'timeout ' . vrcCurlTimeout . ' curl --silent ' . join(curlArgs) . ' ' . s:Shellescape(a:request.host . a:request.requestPath),
     \ curlOpts
   \]
 endfunction

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -686,6 +686,8 @@ function! s:DisplayOutput(tmpBufName, outputInfo, config)
               \ 'g'
             \)
           endif
+          " Character u2001
+          call append('$', " ")
           call append('$', split(formattedBody, '\v\n'))
         elseif s:GetOpt('vrc_debug', 0)
           echom "VRC: auto-format error: " . v:shell_error
@@ -699,7 +701,8 @@ function! s:DisplayOutput(tmpBufName, outputInfo, config)
       syntax clear
       try
         execute "syntax include @vrc_" . fileType . " syntax/" . fileType . ".vim"
-        execute "syntax region body start=/^$/ end=/\%$/ contains=@vrc_" . fileType
+        " Character u2001
+        execute "syntax region body start=/ / end=/\%$/ contains=@vrc_" . fileType
       catch
       endtry
     endif
@@ -707,6 +710,7 @@ function! s:DisplayOutput(tmpBufName, outputInfo, config)
 
   """ Finalize view.
   setlocal nomodifiable
+  execute 'syntax sync fromstart'
   execute origWin . 'wincmd w'
 endfunction
 

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -635,7 +635,7 @@ function! s:DisplayOutput(tmpBufName, outputInfo, config)
       if s:GetOpt('vrc_horizontal_split', 0)
         let cmdSplit = 'split'
       else
-        if &columns <= 120
+        if &columns < s:GetOpt('vrc_flex_columns', '155')
           let cmdSplit = 'split'
         else
           let cmdSplit = 'vsplit'

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -492,8 +492,9 @@ function! s:GetCurlCommand(request)
   if !empty(a:request.dataBody)
     call add(curlArgs, s:GetCurlDataArgs(a:request))
   endif
+  let vrcCurlTimeout = s:GetOpt('vrc_curl_timeout', '1m')
   return [
-    \ 'curl ' . join(curlArgs) . ' ' . s:Shellescape(a:request.host . a:request.requestPath),
+    \ 'timeout ' . vrcCurlTimeout . ' curl ' . join(curlArgs) . ' ' . s:Shellescape(a:request.host . a:request.requestPath),
     \ curlOpts
   \]
 endfunction

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -731,20 +731,31 @@ function! s:DisplayOutput(tmpBufName, outputInfo, config)
 
   """ Display commands in result buffer if any.
   if s:GetOpt('vrc_show_command_in_result_buffer', 0)
-    if (!empty(a:outputInfo['commands']))
-      let prefixedList = map(copy(a:outputInfo['commands']), '"REQUEST: " . v:val . "\t"') 
+    if (!empty(a:outputInfo['commands']) && includeResponseHeader)
+      let prefixedList = map(copy(a:outputInfo['commands']), '"REQUEST: " . v:val')
       call append(0, prefixedList)
-      call append(1, '')
+    else
+      execute '1delete _'
     endif
+  else
+    execute '1delete _'
   endif
 
   """ Finalize view.
-  execute '1delete _'
+  if includeResponseHeader
+    call append(0, '/*')
+    call append(search('\v^\s*$', 'n')-1, '*/')
+  endif
+
   " WTF:
   call timer_start(10, { tid -> execute('normal "_ddu')})
-  call timer_start(20, { tid -> execute('normal GzxggzMzrzr')})
-  " call timer_start(50, { tid -> execute('setlocal nomodifiable')})
-  call timer_start(100, { tid -> execute(origWin . 'wincmd w')})
+  if includeResponseHeader
+    call timer_start(30, { tid -> execute('normal GzxggzMzrzrza')})
+  else
+    call timer_start(30, { tid -> execute('normal GzxggzMzr')})
+  endif
+  call timer_start(150, { tid -> execute('setlocal nomodifiable')})
+  call timer_start(250, { tid -> execute(origWin . 'wincmd w')})
 endfunction
 
 """


### PR DESCRIPTION
If we use 'clipboard' to sync `*` or `+` registers after each delete
operation, then each time we run a request, all output buffers gets
copied to the clipboard