### PR TITLE
Add piping output to some command line

### DIFF
--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -784,9 +784,7 @@ function! s:RunQuery(start, end)
     redraw!
 
     call add(outputInfo['outputChunks'], system(curlCmd . request.pipe))
-    " call add(outputInfo['outputChunks'], system(curlCmd))
     if shouldShowCommand
-      " call add(outputInfo['commands'], system(curlCmd . '| jq .'))
       call add(outputInfo['commands'], curlCmd)
     endif
     let resumeFrom = request.resumeFrom

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -230,7 +230,7 @@ function! s:ParseHeaders(start, end)
   let hasContentType = 0
   for line in lineBuf
     let line = s:StrTrim(line)
-    if line ==? '' || line =~? s:vrc_comment_delim || line =~? '\v^--?\w+'
+    if line =~ '^|' || line ==? '' || line =~? s:vrc_comment_delim || line =~? '\v^--?\w+'
       continue
     endif
     let sepIdx = stridx(line, ':')
@@ -259,7 +259,7 @@ function! s:ParseVals(start, end)
 
   for line in lineBuf
     let line = s:StrTrim(line)
-    if line ==? '' || line =~? s:vrc_comment_delim
+    if line =~ '^|' || line ==? '' || line =~? s:vrc_comment_delim
       continue
     endif
     let sepIdx = stridx(line, '=')


### PR DESCRIPTION
This pr will enable piping the output into some command line.
if a line start with pipe(|) thats means all of output of curl command
will be pipe into that line e.g

```
http://localhost:8000
--silent

# this is global pipe command, https://stedolan.github.io/jq/
| jq .

--

--

# using global pipe commands

GET /v1/users

--

# using custom pip command

| jq '.name'

GET  /v1/users/1

--

# using custom pipe command
# sometimes the apps error and didnt give a proper json so jq will fail
# while parse the output, so we need to pipe it to file first

| tee /tmp/fail.log | jq '.name'

GET  /v1/users/1

```