### PR TITLE
Make http headers case-insensitive

### DIFF
--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -194,13 +194,12 @@ endfunction
 "
 function! s:ParseHeaders(start, end)
   let contentTypeOpt = s:GetOpt('vrc_header_content_type', 'application/json')
-  let headers = {'Content-Type': contentTypeOpt}
+  let headers = {'content-type': contentTypeOpt}
   if (a:end < a:start)
     return headers
   endif
 
   let lineBuf = getline(a:start, a:end)
-  let hasContentType = 0
   for line in lineBuf
     let line = s:StrTrim(line)
     if line ==? '' || line =~? s:vrc_comment_delim || line =~? '\v^--?\w+'
@@ -208,7 +207,7 @@ function! s:ParseHeaders(start, end)
     endif
     let sepIdx = stridx(line, ':')
     if sepIdx > -1
-      let key = s:StrTrim(line[0:sepIdx - 1])
+      let key = tolower(s:StrTrim(line[0:sepIdx - 1]))
       let headers[key] = s:StrTrim(line[sepIdx + 1:])
     endif
   endfor


### PR DESCRIPTION
Hi,

I was running into an issue where I was trying to set the content-type header to x-www-form-urlencoded, but VRC was sending TWO content-type headers, one with my value, and one with type json.

It looks like internally the default content-type is json and is set with the key "Content-Type". When I set the "content-type" header, the default wasn't being overridden because it uses a different case.

This PR makes all http headers lowercase upon processing so that you can't send multiple of the same header. Note that http headers are case-insensitive in the spec. https://stackoverflow.com/a/5259004