### PR TITLE
Alot of changes

### DIFF
--- a/syntax/rest.vim
+++ b/syntax/rest.vim
@@ -227,8 +227,13 @@ highlight link restHost Label
 syntax match restKeyword '\c\v^\s*(GET|POST|PUT|DELETE|HEAD|PATCH|OPTIONS|TRACE)\s'
 highlight link restKeyword Macro
 
-syntax match restComment '\v^\s*(#|//).*$'
 highlight link restComment Comment
+syntax match restComment '\v^\s*(#|//).*$'
 
+syntax match GQLKeyword '\c\v^\s*GQL\s'
+highlight link GQLKeyword Macro
+
+syn include @GraphQLSyntax syntax/graphql.vim
+syntax region GQLQuery start=+GQL+ end=+\n#.*+ keepend contains=@GraphQLSyntax
 
 let b:current_syntax = 'rest'


### PR DESCRIPTION
• GraphQL integration
   - Added GQL tag to perform graphql queries
        EXAMPLE:
        https://countries.trevorblades.com

        GQL
        query {
          continents {
            code
            name
          }
        }
   - Add Syntax Highlighting of GQL queries [ vim-graphql Needed ].

• Syntax Highlighted Headers.
  - change default by opt| g:vrc_default_header_highlights
  - Defualt syn groups are
     = vrc_httpHeader
     = vrc_http200
     = vrc_http300
     = vrc_http400
     = vrc_http500
     = vrc_header

• Ability to open VrcQuery() in new buffer.
  - g:vrc_new_buffer

• Added Host Can't be Resolved Error

NOTE - Forgot to update Docs