### PR TITLE
Fixed curl progress output included in responds

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To install using [pathogen.vim](https://github.com/tpope/vim-pathogen)
 To install using [Vundle](https://github.com/gmarik/Vundle.vim)
 
     " Add this line to .vimrc
-    Plugin 'diepm/vim-rest-console'
+    Plugin 'D3faIt/vim-rest-console'
 
 Other methods should work as well.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To install using [pathogen.vim](https://github.com/tpope/vim-pathogen)
 To install using [Vundle](https://github.com/gmarik/Vundle.vim)
 
     " Add this line to .vimrc
-    Plugin 'D3faIt/vim-rest-console'
+    Plugin 'diepm/vim-rest-console'
 
 Other methods should work as well.
 

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -493,7 +493,7 @@ function! s:GetCurlCommand(request)
     call add(curlArgs, s:GetCurlDataArgs(a:request))
   endif
   return [
-    \ 'curl ' . join(curlArgs) . ' ' . s:Shellescape(a:request.host . a:request.requestPath),
+    \ 'curl --silent ' . join(curlArgs) . ' ' . s:Shellescape(a:request.host . a:request.requestPath),
     \ curlOpts
   \]
 endfunction


### PR DESCRIPTION
Without `curl --silence`, it causes the respond to contain the progress of the request, like the example below:

**without silent**
```
curl http://192.168.1.101:9200/ | cat

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   536  100   536    0     0   261k      0 --:--:-- --:--:-- --:--:--  261k
{
  "name" : "gallery",
  "cluster_name" : "elasticsearch",
  "cluster_uuid" : "j7ij07pdSISexz53Rt7gPA",
  "version" : {
    "number" : "7.12.0",
    "build_flavor" : "default",
    "build_type" : "deb",
    "build_hash" : "78722783c38caa25a70982b5b042074cde5d3b3a",
    "build_date" : "2021-03-18T06:17:15.410153305Z",
    "build_snapshot" : false,
    "lucene_version" : "8.8.0",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  },
  "tagline" : "You Know, for Search"
}
```

**with silent**

```
curl --silent http://192.168.1.101:9200/ | cat

{
  "name" : "gallery",
  "cluster_name" : "elasticsearch",
  "cluster_uuid" : "j7ij07pdSISexz53Rt7gPA",
  "version" : {
    "number" : "7.12.0",
    "build_flavor" : "default",
    "build_type" : "deb",
    "build_hash" : "78722783c38caa25a70982b5b042074cde5d3b3a",
    "build_date" : "2021-03-18T06:17:15.410153305Z",
    "build_snapshot" : false,
    "lucene_version" : "8.8.0",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  },
  "tagline" : "You Know, for Search"
}
```

*Using "cat" pipe as it gives the same result as the plugin does*