### PR TITLE
Fix lowercase "content-type" was ignored

### DIFF
--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -209,7 +209,7 @@ function! s:ParseHeaders(start, end)
     let sepIdx = stridx(line, ':')
     if sepIdx > -1
       let key = s:StrTrim(line[0:sepIdx - 1])
-      let headers[key] = s:StrTrim(line[sepIdx + 1:])
+      let headers[key == 'content-type' ? 'Content-Type' : key] = s:StrTrim(line[sepIdx + 1:])
     endif
   endfor
   return headers


### PR DESCRIPTION
When specifying the header Content-Type, only uppercase "Content-Type" works but lowercase "content-type" is ignored and overridden by g:vrc_header_content_type.

**Solution:**
When the user specifies "content-type" the plugin will automatically uppercase to "Content-Type" to match the existing logic.